### PR TITLE
Update to 11.8

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,24 +1,12 @@
 set -ex
 
-RUNFILE="cuda_11.3.1_465.19.01_linux.run"
-EMBEDDED_RUNFILE="cuda_11.3.1_465.19.01_linux.run"
-TMPDIR="${SRC_DIR}/unpacked"
-RUNDIR="${SRC_DIR}/rundir"
+TMPDIR="${SRC_DIR}/tmp"
 
-cp -f ~/nvidia/$RUNFILE .
-
-# unpack the embedded runfiles
-chmod +x ${RUNFILE}
-mkdir -p ${RUNDIR}
-./$RUNFILE --extract=$RUNDIR --nox11 --silent
-
-# unpack the runfile
+# Extract the whole cuda library
+chmod +x ${runfile_name}
 mkdir -p ${TMPDIR}
-./$EMBEDDED_RUNFILE --tmpdir=$TMPDIR --silent --nox11
+./${runfile_name} --extract=$TMPDIR --nox11 --silent
 
-# copy library to prefix
+# copy cupti libraries to prefix, preserving symlinks
 mkdir -p $PREFIX/lib
-cp rundir/cuda_cupti/extras/CUPTI/lib64/* $PREFIX/lib/
-
-# create symlinks
-cd $PREFIX/lib
+cp --no-dereference ${TMPDIR}/cuda_cupti/extras/CUPTI/lib64/* $PREFIX/lib/

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+# Runfile name and URL from
+# https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=CentOS&target_version=7&target_type=runfile_local
+runfile_name:
+  cuda_11.8.0_520.61.05_linux.run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
   sha256: 9223c4af3aebe4a7bbed9abd9b163b03a1b34b855fbc2b4a0d1b706ac09a5a16 
 build:
   number: 0
+  missing_dso_whitelist:
+    - '*'
 
 requirements:
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,14 +4,12 @@ package:
   name: cupti
   version: {{ cupti_version }}
 
-# TODO
-# skip everything except linux-64? what platforms currently have cupti (only linux-64) and what recipes need it?
-
 source:
   url: https://developer.download.nvidia.com/compute/cuda/{{ cupti_version }}/local_installers/{{ runfile_name }}
   sha256: 9223c4af3aebe4a7bbed9abd9b163b03a1b34b855fbc2b4a0d1b706ac09a5a16 
 build:
   number: 0
+  skip: True # [not (linux and x86_64)]
   missing_dso_whitelist:
     - '*'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ test:
 # CUDA Profiling Tools Interface (CUPTI) Library
 about:
   home: https://developer.nvidia.com/cuda-toolkit
-  license: proprietary - Nvidia
+  license: LicenseRef-ProprietaryNvidia
   license_family: Proprietary
   summary: development environment for GPU-accelerated applications, CUPTI components
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,27 @@
+{% set cupti_version= "11.8.0" %}
+
 package:
   name: cupti
-  version: 11.3.1
+  version: {{ cupti_version }}
+
+# TODO
+# skip everything except linux-64? what platforms currently have cupti (only linux-64) and what recipes need it?
 
 source:
-  path: .
+  url: https://developer.download.nvidia.com/compute/cuda/{{ cupti_version }}/local_installers/{{ runfile_name }}
+  sha256: 9223c4af3aebe4a7bbed9abd9b163b03a1b34b855fbc2b4a0d1b706ac09a5a16 
 build:
   number: 0
 
 requirements:
   run:
-    cudatoolkit >=11.3,<11.4
+    # from https://docs.nvidia.com/cupti/r_main.html#r_compatibility_requirements
+    cudatoolkit >={{ cupti_version }}
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libcupti.so           # [linux]
-    - test -f ${PREFIX}/lib/libcupti.so.11.3      # [linux]
+    - test -f ${PREFIX}/lib/libcupti.so
+    - test -f ${PREFIX}/lib/libcupti.so.{{ '.'.join(cupti_version.split('.')[0:2]) }}
 
 # CUDA Profiling Tools Interface (CUPTI) Library
 about:


### PR DESCRIPTION
# Links
[jira ticket](https://anaconda.atlassian.net/browse/PKG-2402)
[Upstream documentation](https://docs.nvidia.com/cupti/)

# Changes
- Automatedly download the runfile
- Remove legacy runfile stuff
- Simplify the instructions in build.sh
- Make the recipe more generic using template variables and a cbc.yaml
- Specify the cudatoolkit compatibility according to nvidia docs
- Whitelist all dso's - there's a fairly long list of them, so just used `*`
- Only build for linux-64 as it's the only platform needed for pytorch or tensorflow (and it's not needed anywhere else)